### PR TITLE
feat: prevent accidental closing of game

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,11 @@
   <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
+    <script>
+      window.addEventListener('beforeunload', function (e) {
+        e.preventDefault();
+        e.returnValue = '';
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
while i was playing through Half-Life: Day One, i ran into an issue where i would consistently close the game due to Ctrl + W also being the shortcut to close the game. (skill issue?) it got annoying so i added a hook to the `beforeunload` event which shows a popup asking if you wish to close the tab instead of just immediately shutting down.